### PR TITLE
[MacCoolApp_DontLink] Set "--linkplatform" as additional  mmp arguments in Release config

### DIFF
--- a/MacCoolApp_DontLink/MacCoolApp/MacCoolApp.csproj
+++ b/MacCoolApp_DontLink/MacCoolApp/MacCoolApp.csproj
@@ -52,6 +52,7 @@
     <CodeSignProvision>cc09f1f3-7939-4e0e-a5fc-807db3c1ef1c</CodeSignProvision>
     <CodeSignEntitlements>Entitlements.plist</CodeSignEntitlements>
     <Profiling>false</Profiling>
+    <MonoBundlingExtraArgs>--linkplatform</MonoBundlingExtraArgs>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
Only for Release config